### PR TITLE
the name should match in volumeMounts, so add -volume

### DIFF
--- a/Chapter10/statefulset-output.yaml
+++ b/Chapter10/statefulset-output.yaml
@@ -16,7 +16,7 @@ spec:
   	- name: app-2
     	  image: mycustomrepository/app-2:latest
     	  volumeMounts:
-    	    - name: scratch
+    	    - name: scratch-volume
       	      mountPath: /scratch
   	- name: sidecar
     	  image: mycustomrepository/tracing-sidecar


### PR DESCRIPTION
should have names matched,

    	  volumeMounts:
    	    - name: scratch-volume  # add "-volume" to match volumes name: scratch-volume on L#24